### PR TITLE
Add Harvard email addresses

### DIFF
--- a/website/organizationWhitelist.txt
+++ b/website/organizationWhitelist.txt
@@ -3,6 +3,8 @@ Cornell - cornell.edu
 NYU - nyu.edu
 Stanford - stanford.edu
 Harvard - harvard.edu
+Harvard - g.harvard.edu
+Harvard - fas.harvard.edu
 Princeton - princeton.edu
 Yale - yale.edu
 Columbia - columbia.edu


### PR DESCRIPTION
It seems the program identify the email address by splitting by @, rather than check ends with same string, so add more related email addresses. Feel free to reject me if I'm wrong.