### PR TITLE
Fix runGame.bat to work on Windows.

### DIFF
--- a/airesources/C++/runGame.bat
+++ b/airesources/C++/runGame.bat
@@ -1,3 +1,3 @@
 g++ -std=c++11 MyBot.cpp -o MyBot.exe
 g++ -std=c++11 RandomBot.cpp -o RandomBot.exe
-.\halite.exe -d "30 30" "./MyBot.exe" "./RandomBot.exe"
+.\halite.exe -d "30 30" "MyBot.exe" "RandomBot.exe"


### PR DESCRIPTION
With "./" in there you get an error saying "'.' is not recognized as an internal or external command,"