### PR TITLE
change -I ../environment  to . in make.bat

### DIFF
--- a/environment/make.bat
+++ b/environment/make.bat
@@ -1,1 +1,1 @@
-g++ -o2 -std=c++11 main.cpp core/Halite.cpp -I ../environment networking/Networking.cpp -o environment.exe -static
+g++ -o2 -std=c++11 main.cpp core/Halite.cpp -I . networking/Networking.cpp -o halite.exe -static


### PR DESCRIPTION
... why?
Simply because compiling in the same directory is hard if i have to copy the tclap/ directory in another directory called ../environment that i need to create. Or, the other way around: This way it's simpler. Dont you think? :smile:

EDIT: To clarify: You give out on the website a ZIP containing ONLY the environment directory contents, but not the directory itself. This way you can avoid having it.
The executable name-change is made there because nothing in the other sources directs to a "environment.exe" or the linux binarys; And here we can compile and copy without even renaming it(Any executable is called halite or halite.exe in any source... the Makefile also points to hailte ELF-Binary)
EDIT2: This one: https://halite.io/downloads/environment/HaliteEnvironment-Source.zip