### PR TITLE
Fix production values used when initializing a GameMap in the Ruby Kit

### DIFF
--- a/airesources/Ruby/networking.rb
+++ b/airesources/Ruby/networking.rb
@@ -66,7 +66,7 @@ class Networking
   end
 
   def init_map_production
-    @production = read_ints_from_input.each_slice(width).to_a
+    @production = read_ints_from_input
   end
 
   def init_map


### PR DESCRIPTION
Values for production were stored as a 2d array of values, but the GameMap initializer was expecting a flattened array.

This currently prevents using a site's production value in the bots.