### PR TITLE
Rust: adding get_site_ref method to types in starter package

### DIFF
--- a/airesources/Rust/src/hlt/types.rs
+++ b/airesources/Rust/src/hlt/types.rs
@@ -70,4 +70,8 @@ impl GameMap {
         let loc = self.get_location(l, d);
         &mut self.contents[loc.y as usize][loc.x as usize]
     }
+    pub fn get_site_ref(&self, l: Location, d: u8) -> &Site {
+        let loc = self.get_location(l, d);
+        &self.contents[loc.y as usize][loc.x as usize]
+    }
 }


### PR DESCRIPTION
Adding a `get_site_ref` method to `types.rs` as most calls to `get_site` do not require a mutable reference. As only one mutable reference is allowed in rust this would prevent multiple calls of `get_site` as the reference would continue to exist in the scope.

This PR's method allows the developer to ask for a immutable reference, which is what they want most of the time, in order to avoid problems with the Rust Borrow Checker.