### PR TITLE
Let javac use UTF-8 encoding, and look for MyBot.class

### DIFF
--- a/worker/compiler.py
+++ b/worker/compiler.py
@@ -253,7 +253,7 @@ comp_args = {
     "Groovy"    : [["groovyc"],
                              ["jar", "cfe", BOT + ".jar", BOT]],
     "Haskell" : [["ghc", "--make", BOT + ".hs", "-O", "-v0"]],
-    "Java"        : [["javac", "-J-Xmx%sm" % (MEMORY_LIMIT)]],
+    "Java"        : [["javac", "-encoding", "UTF-8", "-J-Xmx%sm" % (MEMORY_LIMIT)]],
     "Lisp"      : [['sbcl', '--dynamic-space-size', str(MEMORY_LIMIT), '--script', BOT + '.lisp']],
     "OCaml"     : [["ocamlbuild -lib unix", BOT + ".native"]],
     "Pascal"    : [["fpc", "-Mdelphi", "-Si", "-O3", "-Xs", "-v0", "-o" + BOT]],
@@ -348,7 +348,7 @@ languages = (
     Language("Java", BOT +".java", "MyBot.java",
         "java MyBot",
         ["*.class", "*.jar"],
-        [(["*.java"], ErrorFilterCompiler(comp_args["Java"][0], filter_stderr="Note:"))]
+        [(["*.java"], ErrorFilterCompiler(comp_args["Java"][0], filter_stderr="Note:", out_files=["MyBot.class"]))]
     ),
     Language("Javascript", BOT +".js", "MyBot.js",
         "node MyBot.js",


### PR DESCRIPTION
#217 exposed some issues with Java submissions:

* Compilation may seem to succeed when it actually doesn't
* The encoding used when calling `javac` is environment-dependent

As Java files doesn't _have_ to produce class files with the same name as the file itself, we cannot use `out_ext` as it would create false positives. However,  we do know that `MyBot.class` will exist, and we can check for that one.

The Docker environment causes the javac compiler to run with ASCII encoding, which causes trouble with... non-ASCII values in source code. The typical default encoding for Javac on more or less all system these days is UTF-8, which is also backwards compatible with ASCII. Therefore it should be fine to set UTF-8 as default encoding for javac.

I haven't tested this with the Python code in a running environment as I was unable to get it set up, so I've only ran it by calling functions manually through a Python REPL. 