### PR TITLE
bugfix for get_location directions

### DIFF
--- a/airesources/OCaml/halite.ml
+++ b/airesources/OCaml/halite.ml
@@ -175,6 +175,7 @@ let process_line state line =
 
 let get_frame state =
   state.round <- state.round + 1;
+  state.last_update <- get_time();
   let line = read_line () in
     process_line state line
 ;;

--- a/airesources/OCaml/halite.ml
+++ b/airesources/OCaml/halite.ml
@@ -288,9 +288,9 @@ let get_location state loc direction =
     match direction with
     | `Still -> (0, 0)
     | `North -> (-1, 0)
-    | `East -> (1, 0)
-    | `South -> (0, -1)
-    | `West -> (0, 1)
+    | `East -> (0, 1)
+    | `South -> (1, 0)
+    | `West -> (0, -1)
   in
   let row = loc.row + o_row in
   let col = loc.col + o_col in


### PR DESCRIPTION
Apologies, I discovered a bug in the movement directions today for the OCaml starter.