### PR TITLE
Install a parent death signal in child processes

### DIFF
--- a/environment/networking/Networking.cpp
+++ b/environment/networking/Networking.cpp
@@ -271,10 +271,23 @@ void Networking::startAndConnectBot(std::string command) {
         throw 1;
     }
 
+    pid_t ppid_before_fork = getpid();
+
     //Fork a child process
     pid = fork();
     if(pid == 0) { //This is the child
         setpgid(getpid(), getpid());
+
+        // install a parent death signal
+        // http://stackoverflow.com/a/36945270
+        int r = prctl(PR_SET_PDEATHSIG, SIGTERM);
+        if (r == -1)
+        {
+            if(!quiet_output) std::cout << "Error installing parent death signal\n";
+            throw 1;
+        }
+        if (getppid() != ppid_before_fork)
+            exit(1);
 
         dup2(writePipe[0], STDIN_FILENO);
 

--- a/environment/networking/Networking.hpp
+++ b/environment/networking/Networking.hpp
@@ -16,6 +16,7 @@
     #include <sys/stat.h>
     #include <fcntl.h>
     #include <sys/select.h>
+    #include <sys/prctl.h>
     #include <unistd.h>
 #endif
 


### PR DESCRIPTION
Right now when the game environment `halite` is terminated (say by `SIGINT`), it leaves all the spawned bots behind.
To see this using the C++ starter package: run a game like `./halite -d "40 40" "./MyBot.o" "./RandomBot.o"`, press Ctrl-C while the game is still running (gotta be quick to catch it!), and check `ps -ef | grep MyBot.o`.

This commit fixes this issue for Linux. (No idea about Windows, as reported in #175.)

It installs a `PR_SET_PDEATHSIG` signal in each spawn child process. This ensures that all bots spawned by the game environment are properly killed when the environment itself is interrupted / terminated.