### PR TITLE
Finding matches now uses mu instead of rank

### DIFF
--- a/website/api/manager/ManagerAPI.php
+++ b/website/api/manager/ManagerAPI.php
@@ -94,7 +94,11 @@ class ManagerAPI extends API{
             }
             if(count($seedPlayer) < 1) return null;
 
-            $players = $this->selectMultiple("SELECT * FROM User WHERE isRunning=1 and ABS(mu-{$seedPlayer['mu']}) < (5 / pow(rand(), 0.65)) and userID <> {$seedPlayer['userID']} ORDER BY rand() LIMIT ".($numPlayers-1));
+            $matchMakingRank = $seedPlayer['rank']
+            if ($seedPlayer['numGames'] < 25) {
+                $matchMakingRank /= 2
+            }
+            $players = $this->selectMultiple("SELECT * FROM User WHERE isRunning=1 and ABS(rank-{$matchMatchingRank}) < (5 / pow(rand(), 0.65)) and userID <> {$seedPlayer['userID']} ORDER BY rand() LIMIT ".($numPlayers-1));
             array_push($players, $seedPlayer);
 
             // Pick map size

--- a/website/api/manager/ManagerAPI.php
+++ b/website/api/manager/ManagerAPI.php
@@ -94,7 +94,7 @@ class ManagerAPI extends API{
             }
             if(count($seedPlayer) < 1) return null;
 
-            $players = $this->selectMultiple("SELECT * FROM User WHERE isRunning=1 and ABS(rank-{$seedPlayer['rank']}) < (5 / pow(rand(), 0.65)) and userID <> {$seedPlayer['userID']} ORDER BY rand() LIMIT ".($numPlayers-1));
+            $players = $this->selectMultiple("SELECT * FROM User WHERE isRunning=1 and ABS(mu-{$seedPlayer['mu']}) < (5 / pow(rand(), 0.65)) and userID <> {$seedPlayer['userID']} ORDER BY rand() LIMIT ".($numPlayers-1));
             array_push($players, $seedPlayer);
 
             // Pick map size

--- a/website/api/manager/ManagerAPI.php
+++ b/website/api/manager/ManagerAPI.php
@@ -94,7 +94,7 @@ class ManagerAPI extends API{
             }
             if(count($seedPlayer) < 1) return null;
 
-            $muRankLimit = intval(5.0 / pow((float)mt_rand(1, mt_getrandmax())/(float)mt_getrandmax()), 0.65));
+            $muRankLimit = intval(5.0 / pow((float)mt_rand(1, mt_getrandmax())/(float)mt_getrandmax(), 0.65));
             $players = $this->selectMultiple("SELECT * FROM (SELECT * FROM User WHERE isRunning=1 and userID <> {$seedPlayer['userID']} ORDER BY ABS(mu-{$seedPlayer['mu']}) LIMIT $muRankLimit) muRankTable ORDER BY rand() LIMIT ".($numPlayers-1));
             array_push($players, $seedPlayer);
 

--- a/website/api/manager/ManagerAPI.php
+++ b/website/api/manager/ManagerAPI.php
@@ -94,11 +94,7 @@ class ManagerAPI extends API{
             }
             if(count($seedPlayer) < 1) return null;
 
-            $matchMakingRank = $seedPlayer['rank']
-            if ($seedPlayer['numGames'] < 10) {
-                $matchMakingRank /= 2
-            }
-            $players = $this->selectMultiple("SELECT * FROM User WHERE isRunning=1 and ABS(rank-{$matchMatchingRank}) < (5 / pow(rand(), 0.65)) and userID <> {$seedPlayer['userID']} ORDER BY rand() LIMIT ".($numPlayers-1));
+            $players = $this->selectMultiple("SELECT * FROM User WHERE userID = (SELECT userID FROM User WHERE isRunning=1 and userID <> {$seedPlayer['userID']} ORDER BY ABS(mu-{$seedPlayer['mu']}) LIMIT (5 / pow(rand(), 0.65)) ORDER BY rand() LIMIT ".($numPlayers-1));
             array_push($players, $seedPlayer);
 
             // Pick map size

--- a/website/api/manager/ManagerAPI.php
+++ b/website/api/manager/ManagerAPI.php
@@ -95,7 +95,7 @@ class ManagerAPI extends API{
             if(count($seedPlayer) < 1) return null;
 
             $matchMakingRank = $seedPlayer['rank']
-            if ($seedPlayer['numGames'] < 25) {
+            if ($seedPlayer['numGames'] < 10) {
                 $matchMakingRank /= 2
             }
             $players = $this->selectMultiple("SELECT * FROM User WHERE isRunning=1 and ABS(rank-{$matchMatchingRank}) < (5 / pow(rand(), 0.65)) and userID <> {$seedPlayer['userID']} ORDER BY rand() LIMIT ".($numPlayers-1));

--- a/website/api/manager/ManagerAPI.php
+++ b/website/api/manager/ManagerAPI.php
@@ -94,7 +94,8 @@ class ManagerAPI extends API{
             }
             if(count($seedPlayer) < 1) return null;
 
-            $players = $this->selectMultiple("SELECT * FROM User WHERE userID = (SELECT userID FROM User WHERE isRunning=1 and userID <> {$seedPlayer['userID']} ORDER BY ABS(mu-{$seedPlayer['mu']}) LIMIT (5 / pow(rand(), 0.65)) ORDER BY rand() LIMIT ".($numPlayers-1));
+            $muRankLimit = intval(5.0 / pow((float)mt_rand(1, mt_getrandmax())/(float)mt_getrandmax()), 0.65));
+            $players = $this->selectMultiple("SELECT * FROM (SELECT * FROM User WHERE isRunning=1 and userID <> {$seedPlayer['userID']} ORDER BY ABS(mu-{$seedPlayer['mu']}) LIMIT $muRankLimit) muRankTable ORDER BY rand() LIMIT ".($numPlayers-1));
             array_push($players, $seedPlayer);
 
             // Pick map size


### PR DESCRIPTION
As suggested here: http://forums.halite.io/t/faster-ranking-in-matchmaking/466

Open Questions:
1. there is no guarantee that anyone will have a mu "near enough" to us to match against, what should we do about this?
2. Do we always want to use sigma? or do we just want to use it for the first x games? or until our sigma is low?
3. should we change the query to look for other bots with a low sigma?