### PR TITLE
Fixed KU Leuven organization

### DIFF
--- a/website/organizationWhitelist.txt
+++ b/website/organizationWhitelist.txt
@@ -93,4 +93,4 @@ DoubleDutch - doubledutch.me
 RWTH Aachen - rwth-aachen.de
 University of Aveiro - ua.pt
 Allstate - allstate.com
-KU Leuven - kuleuven.be
+KU Leuven - student.kuleuven.be


### PR DESCRIPTION
Changed organization address from kuleuven.be to student.kuleuven.be.