### PR TITLE
Set a cap on visualizer FPS to reduce load

### DIFF
--- a/website/script/visualizer.js
+++ b/website/script/visualizer.js
@@ -401,7 +401,10 @@ function showGame(game, $container, maxWidth, maxHeight, showmovement, isminimal
         renderer.render(stage);
 
         //Of course, we want to render in the future as well.
-        requestAnimationFrame(animate);
+        var idle = (Object.keys(pressed).length === 0) && !shouldplay;
+        setTimeout(function() {
+            requestAnimationFrame(animate);
+        }, 1000 / (idle ? 6.0 : 60.0));
     }
 }
 


### PR DESCRIPTION
Currently the visualizer draws frames continuously without intermittence. This drives my poor laptop CPU to 100% usage and the fan kicks in shortly afterwards. I can actually smell the pleasant aroma of overheating plastics in under 10 seconds if I forget to close the visualizer tab.

This pull request puts a cap on the refresh rate to 60 FPS through a simple "setTimeout" delay. To further reduce CPU load, the refresh rate is capped down to 10 FPS when the game is paused with no key being pressed.