### PR TITLE
Record and report last_frame_alive for each bot

### DIFF
--- a/environment/core/Halite.cpp
+++ b/environment/core/Halite.cpp
@@ -364,6 +364,10 @@ GameStatistics Halite::runGame(std::vector<std::string> * names_, unsigned int s
         PlayerStatistics p;
         p.tag = a + 1;
         p.rank = std::distance(rankings.begin(), std::find(rankings.begin(), rankings.end(), a)) + 1;
+        // alive_frame_count counts frames, but the frames are 0-base indexed (at least in the visualizer), so everyone needs -1 to find the frame # where last_alive
+        // however, the first place player and 2nd place player always have the same reported alive_frame_count (not sure why)
+        // it turns out to make "last_frame_alive" match what is seen in replayer, we have to -2 from all but #1 finisher, who still only needs -1
+        p.last_frame_alive = alive_frame_count[a] - ((p.rank == 1) ? 1 : 2);
         p.average_territory_count = full_territory_count[a] / double(chunkSize * alive_frame_count[a]);
         p.average_strength_count = full_strength_count[a] / double(chunkSize * alive_frame_count[a]);
         p.average_production_count = alive_frame_count[a] > 1 ? full_production_count[a] / double(chunkSize * (alive_frame_count[a] - 1)) : 0; //For this, we want turns rather than frames.

--- a/environment/core/Halite.cpp
+++ b/environment/core/Halite.cpp
@@ -366,8 +366,8 @@ GameStatistics Halite::runGame(std::vector<std::string> * names_, unsigned int s
         p.rank = std::distance(rankings.begin(), std::find(rankings.begin(), rankings.end(), a)) + 1;
         // alive_frame_count counts frames, but the frames are 0-base indexed (at least in the visualizer), so everyone needs -1 to find the frame # where last_alive
         // however, the first place player and 2nd place player always have the same reported alive_frame_count (not sure why)
-        // it turns out to make "last_frame_alive" match what is seen in replayer, we have to -2 from all but #1 finisher, who still only needs -1
-        p.last_frame_alive = alive_frame_count[a] - ((p.rank == 1) ? 1 : 2);
+        // it turns out to make "last_frame_alive" match what is seen in replayer, we have to -2 from all but finishers who are alive in last frame of game who only need -1
+        p.last_frame_alive = alive_frame_count[a] - 2 + result[a];
         p.average_territory_count = full_territory_count[a] / double(chunkSize * alive_frame_count[a]);
         p.average_strength_count = full_strength_count[a] / double(chunkSize * alive_frame_count[a]);
         p.average_production_count = alive_frame_count[a] > 1 ? full_production_count[a] / double(chunkSize * (alive_frame_count[a] - 1)) : 0; //For this, we want turns rather than frames.

--- a/environment/core/Halite.hpp
+++ b/environment/core/Halite.hpp
@@ -19,6 +19,7 @@ extern bool quiet_output;
 struct PlayerStatistics {
     int tag;
     int rank;
+    int last_frame_alive;
     double average_territory_count;
     double average_strength_count;
     double average_production_count;
@@ -27,7 +28,7 @@ struct PlayerStatistics {
     double average_frame_response_time;
 };
 static std::ostream & operator<<(std::ostream & o, const PlayerStatistics & p) {
-    o << p.tag << ' ' << p.rank;// << ' ' << p.average_territory_count << ' ' << p.average_strength_count << ' ' << p.average_production_count << ' ' << p.still_percentage << ' ' << p.average_response_time;
+    o << p.tag << ' ' << p.rank << ' ' << p.last_frame_alive;// << ' ' << p.average_territory_count << ' ' << p.average_strength_count << ' ' << p.average_production_count << ' ' << p.still_percentage << ' ' << p.average_response_time;
     return o;
 }
 

--- a/environment/main.cpp
+++ b/environment/main.cpp
@@ -130,7 +130,7 @@ int main(int argc, char ** argv) {
         std::cout << stats;
     }
     else {
-        for(unsigned int a = 0; a < stats.player_statistics.size(); a++) std::cout << "Player #" << stats.player_statistics[a].tag << ", " << my_game->getName(stats.player_statistics[a].tag) << ", came in rank #" << stats.player_statistics[a].rank << "!\n";
+        for(unsigned int a = 0; a < stats.player_statistics.size(); a++) std::cout << "Player #" << stats.player_statistics[a].tag << ", " << my_game->getName(stats.player_statistics[a].tag) << ", came in rank #" << stats.player_statistics[a].rank << " and was last alive on frame #" << stats.player_statistics[a].last_frame_alive << "!\n";
     }
 
     delete my_game;


### PR DESCRIPTION
in both verbose and quiet.  Last_frame_alive reports how far into the game each bot survives ... more color than just rank finish.  Also, it's the score for single player mode.