### PR TITLE
Enable multi-player maps in single player mode.  

### DIFF
--- a/environment/core/Halite.cpp
+++ b/environment/core/Halite.cpp
@@ -204,12 +204,18 @@ std::vector<bool> Halite::processNextFrame(std::vector<bool> alive) {
 }
 
 //Public Functions -------------------
-Halite::Halite(unsigned short width_, unsigned short height_, unsigned int seed_, Networking networking_, bool shouldIgnoreTimeout) {
+Halite::Halite(unsigned short width_, unsigned short height_, unsigned int seed_, unsigned short n_players_for_map_creation, Networking networking_, bool shouldIgnoreTimeout) {
     networking = networking_;
+    // number_of_players is the number of active bots to start the match; it is constant throughout game
     number_of_players = networking.numberOfPlayers();
 
     //Initialize map
-    game_map = hlt::Map(width_, height_, number_of_players, seed_);
+    game_map = hlt::Map(width_, height_, n_players_for_map_creation, seed_);
+
+    //If this is single-player mode, remove all the extra players (they were automatically inserted in map, just 0 them out)
+    if (number_of_players == 1){
+        for(unsigned short b = 0; b < game_map.map_height; b++) for(unsigned short c = 0; c < game_map.map_width; c++) if(game_map.contents[b][c].owner > 1) game_map.contents[b][c].owner = 0;
+    }
 
     //Default initialize
     player_moves = std::vector< std::map<hlt::Location, unsigned char> >();

--- a/environment/core/Halite.hpp
+++ b/environment/core/Halite.hpp
@@ -56,6 +56,7 @@ private:
     unsigned short turn_number;
     unsigned short number_of_players;
     unsigned short productive_squares_remaining;
+    unsigned short n_players_for_map_creation;
     bool ignore_timeout;
     hlt::Map game_map;
     std::vector<std::string> player_names;
@@ -81,7 +82,7 @@ private:
     std::vector<bool> processNextFrame(std::vector<bool> alive);
     void output(std::string filename);
 public:
-    Halite(unsigned short width_, unsigned short height_, unsigned int seed_, Networking networking_, bool shouldIgnoreTimeout);
+    Halite(unsigned short width_, unsigned short height_, unsigned int seed_, unsigned short n_players_for_map_creation, Networking networking_, bool shouldIgnoreTimeout);
 
     GameStatistics runGame(std::vector<std::string> * names_, unsigned int seed, unsigned int id);
     std::string getName(unsigned char playerTag);

--- a/environment/main.cpp
+++ b/environment/main.cpp
@@ -43,6 +43,7 @@ int main(int argc, char ** argv) {
     TCLAP::SwitchArg timeoutSwitch("t", "timeout", "Causes game environment to ignore timeouts (give all bots infinite time).", cmd, false);
 
     //Value Args
+    TCLAP::ValueArg<unsigned int> nPlayersArg("n", "nplayers", "Create a map that will accommodate n players [SINGLE PLAYER MODE ONLY].", false, 1, "{1,2,3,4,5,6}", cmd);
     TCLAP::ValueArg< std::pair<signed int, signed int> > dimensionArgs("d", "dimensions", "The dimensions of the map.", false, { 0, 0 }, "a string containing two space-seprated positive integers", cmd);
     TCLAP::ValueArg<unsigned int> seedArg("s", "seed", "The seed for the map generator.", false, 0, "positive integer", cmd);
 
@@ -57,6 +58,8 @@ int main(int argc, char ** argv) {
     unsigned int seed;
     if(seedArg.getValue() != 0) seed = seedArg.getValue();
     else seed = (std::chrono::duration_cast<std::chrono::microseconds>(std::chrono::system_clock::now().time_since_epoch()).count() % 4294967295);
+
+    unsigned short n_players_for_map_creation = nPlayersArg.getValue();
 
     quiet_output = quietSwitch.getValue();
     bool override_names = overrideSwitch.getValue();
@@ -116,8 +119,23 @@ int main(int argc, char ** argv) {
         }
     }
 
+
+    if(networking.numberOfPlayers() > 1 && n_players_for_map_creation != 1) {
+        std::cout << std::endl << "Only single-player mode enables specified n-player maps.  When entering multiple bots, please do not try to specify n." << std::endl << std::endl;
+        exit(1);
+    }
+
+    if(networking.numberOfPlayers() > 1) n_players_for_map_creation = networking.numberOfPlayers();
+
+    if(n_players_for_map_creation > 6 || n_players_for_map_creation < 1) {
+        std::cout << std::endl << "A map can only accommodate between 1 and 6 players." << std::endl << std::endl;
+        exit(1);
+    }
+
+
+
     //Create game. Null parameters will be ignored.
-    my_game = new Halite(mapWidth, mapHeight, seed, networking, ignore_timeout);
+    my_game = new Halite(mapWidth, mapHeight, seed, n_players_for_map_creation, networking, ignore_timeout);
 
     GameStatistics stats = my_game->runGame(names, seed, id);
     if(names != NULL) delete names;


### PR DESCRIPTION
Takes -n command line argument to create a map "as if" there were n players.  If n is specified, single player mode is also required.  This feature allows single-player mode users to play the same maps seen in multi-player competition.