### PR TITLE
Remove cast for pid variable

### DIFF
--- a/environment/networking/Networking.cpp
+++ b/environment/networking/Networking.cpp
@@ -258,7 +258,7 @@ void Networking::startAndConnectBot(std::string command) {
 
     if(!quiet_output) std::cout << command << "\n";
 
-    pid_t pid = (pid_t)NULL;
+    pid_t pid;
     int writePipe[2];
     int readPipe[2];
 


### PR DESCRIPTION
Without this patch, i get this error on FreeBSD 11 / clang 3.8.0:

> networking/Networking.cpp:261:17: error: cast from pointer to smaller type 'pid_t' (aka 'int') loses information
    pid_t pid = (pid_t)NULL;
                ^~~~~~~~~~~
1 error generated.
