### PR TITLE
Lock players from seeding when in a game.

### DIFF
--- a/website/sql/schema.sql
+++ b/website/sql/schema.sql
@@ -54,6 +54,34 @@ CREATE TABLE `GameUser` (
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
+-- Table structure for table `Pairing`
+--
+
+DROP TABLE IF EXISTS `Pairing`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8 */;
+CREATE TABLE `Pairing` (
+  `pairingID` mediumint(8) unsigned NOT NULL AUTO_INCREMENT,
+  `workerID` mediumint(8) unsigned NOT NULL,
+  `timestamp` datetime DEFAULT CURRENT_TIMESTAMP,
+  PRIMARY KEY (`pairingID`)
+) ENGINE=InnoDB AUTO_INCREMENT=1 DEFAULT CHARSET=latin1;
+/*!40101 SET character_set_client = @saved_cs_client */;
+
+--
+-- Table structure for table `PairingUser`
+--
+
+DROP TABLE IF EXISTS `PairingUser`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8 */;
+CREATE TABLE `PairingUser` (
+  `pairingID` mediumint(8) unsigned NOT NULL,
+  `userID` mediumint(8) unsigned NOT NULL,
+) ENGINE=InnoDB DEFAULT CHARSET=latin1;
+/*!40101 SET character_set_client = @saved_cs_client */;
+
+--
 -- Table structure for table `User`
 --
 

--- a/worker/backend.py
+++ b/worker/backend.py
@@ -89,11 +89,11 @@ def compileResult(userID, didCompile, language, errors=None):
     print("Posting compile result")
     print(r.text)
 
-def gameResult(width, height, users, replayPath, errorPaths):
+def gameResult(pairID, width, height, users, replayPath, errorPaths):
     """Posts the result of a game task"""
     files = {os.path.basename(replayPath): open(replayPath, "rb").read()}
     for path in errorPaths:
         files[os.path.basename(path)] = open(path, "rb").read()
-    r = requests.post(MANAGER_URL+"game", data={"apiKey": API_KEY, "mapWidth": str(width), "mapHeight": str(height), "users": json.dumps(users)}, files=files)
+    r = requests.post(MANAGER_URL+"game", data={"apiKey": API_KEY, "pairingID": pairID, "mapWidth": str(width), "mapHeight": str(height), "users": json.dumps(users)}, files=files)
     print("Posting game result:")
     print(r.text)

--- a/worker/worker.py
+++ b/worker/worker.py
@@ -157,8 +157,11 @@ def parseGameOutput(output, users):
 
     return users, replayPath, errorPaths
 
-def executeGameTask(width, height, users, backend):
+def executeGameTask(gameTask, backend):
     """Downloads compiled bots, runs a game, and posts the results of the game"""
+    width = int(gameTask["width"])
+    height = int(gameTask["height"])
+    users = gameTask["users"]
     print("Running game with width %d, height %d, and users %s" % (width, height, str(users)))
 
     downloadUsers(users)
@@ -171,7 +174,7 @@ def executeGameTask(width, height, users, backend):
     fIn.close()
     fOut.close()
 
-    backend.gameResult(width, height, users, replayArchivePath, errorPaths)
+    backend.gameResult(gameTask["pairingID"], width, height, users, replayArchivePath, errorPaths)
     filelist = glob.glob("*.log")
     for f in filelist:
         os.remove(f)
@@ -189,7 +192,7 @@ if __name__ == "__main__":
                 if task["type"] == "compile":
                     executeCompileTask(task["user"], backend)
                 else:
-                    executeGameTask(int(task["width"]), int(task["height"]), task["users"], backend)
+                    executeGameTask(task, backend)
             else:
                 print("No task available. Sleeping...")
                 sleep(2)


### PR DESCRIPTION
This is to fix issue #310.

Currently it is untested (so probably broken) since I do not have a local setup. Also it is only currently locking out high sigma seeding, the other seeding can be locked similarly by updating there queries. The high sigma seeding is the biggest problem though.

I'm putting this up now to make sure that the organizer's are at least in principle interested in changing this and specifically this approach.