### PR TITLE
Force status page to parse times as UTC.

### DIFF
--- a/website/script/status.js
+++ b/website/script/status.js
@@ -32,7 +32,7 @@ $(function() {
         },
         getTableRow: function(worker) {
             console.log(worker.lastRequestTime)
-            var timeSinceCommunication = Math.round(100*((new Date() - new Date(worker.lastRequestTime)) / (1000*60))) / 100;
+            var timeSinceCommunication = Math.round(100*((new Date() - new Date(worker.lastRequestTime+"Z")) / (1000*60))) / 100;
             return "<tr><td>"+worker.workerID+"</td><td>"+timeSinceCommunication+" min</td></tr>";  
         }
     };


### PR DESCRIPTION
This marks the times returned from the server as UTC timezone so that the correct period since last communication with a worker is shown.