### PR TITLE
Update instructions to run halite at the terminal

### DIFF
--- a/website/basics_intro_halite.php
+++ b/website/basics_intro_halite.php
@@ -31,10 +31,10 @@
 
                 <h3>Testing your bot</h3>
                 <p>To play games of Halite locally, you will need the game environment. As of this writing we support Windows, Linux and OSX platforms. You can download the game environment <a href="downloads.php">here</a>. Place the downloaded binary (halite or halite.exe) in your starter kit folder.</p>
-                <p>To simulate a game, simply runGame.sh (Linux and macOS) or runGame.bat (Windows). This command will run a game between my MyBot and RandomBot (both are just copies of each other at this point) on a grid of size 30x30.</p>
+                <p>To simulate a game, simply issue the command ./runGame.sh (Linux and macOS) or runGame.bat (Windows). This command will run a game between my MyBot and RandomBot (both are just copies of each other at this point) on a grid of size 30x30.</p>
                 <p>The output should look like this and the details of the game will be stored in a file with the "hlt" extension (35538-124984302.hlt in the example below).</p>
 
-                <pre><code>$ . runGame.sh 
+                <pre><code>$ ./runGame.sh 
 python3 MyBot.py
 python3 RandomBot.py
 Init Message sent to player 2.


### PR DESCRIPTION
In Mac OSX running `$ . runGame.sh` will not work, there needs to be a '/' inserted as follows `$./runGame.sh`.