### PR TITLE
Two fixes for windows runGame.bat in the clojure starter package

### DIFF
--- a/airesources/Clojure/runGame.bat
+++ b/airesources/Clojure/runGame.bat
@@ -1,3 +1,3 @@
 call lein uberjar
 
-\halite.exe -d "30 30" "java -cp target/MyBot.jar MyBot" "java -cp target/MyBot.jar RandomBot"
+halite.exe -d "30 30" "java -cp target/MyBot.jar MyBot" "java -cp target/MyBot.jar RandomBot"

--- a/airesources/Clojure/runGame.bat
+++ b/airesources/Clojure/runGame.bat
@@ -1,3 +1,3 @@
-lein uberjar
+call lein uberjar
 
 \halite.exe -d "30 30" "java -cp target/MyBot.jar MyBot" "java -cp target/MyBot.jar RandomBot"


### PR DESCRIPTION
Fix 1 adds a 'call' command before the lein uberjar command so that the runGame.bat does not stop after the lein command.

Fix 2 removes the backslash in front of halite.exe so that windows will try to run it out of the current folder.