### PR TITLE
ExternalCompiler returns success if no files to compile

### DIFF
--- a/worker/compiler.py
+++ b/worker/compiler.py
@@ -128,6 +128,9 @@ class ExternalCompiler(Compiler):
         with CD(bot_dir):
             print("GLOBS: " + ", ".join(globs))
             files = safeglob_multi(globs)
+            if (len(files) == 0):
+                # nothing to do
+                return True
 
         try:
             if self.separate:

--- a/worker/compiler.py
+++ b/worker/compiler.py
@@ -128,8 +128,8 @@ class ExternalCompiler(Compiler):
         with CD(bot_dir):
             print("GLOBS: " + ", ".join(globs))
             files = safeglob_multi(globs)
-            if (len(files) == 0):
-                # nothing to do
+            if (len("".join(globs)) != 0 and len(files) == 0):
+                # no files to compile
                 return True
 
         try:


### PR DESCRIPTION
The Scala langauge supports compiling both
Java and Scala, but running Javac with no file
arguments is an error. Preserve support for
combining languages by checking for no files
in a glob and returning success for that compiler.