### PR TITLE
Add primary key to GameUser table.

### DIFF
--- a/website/sql/schema.sql
+++ b/website/sql/schema.sql
@@ -49,7 +49,8 @@ CREATE TABLE `GameUser` (
   `errorLogName` varchar(64) DEFAULT NULL,
   `rank` smallint(5) unsigned NOT NULL,
   `playerIndex` smallint(5) unsigned NOT NULL,
-  `didTimeout` tinyint(1) unsigned NOT NULL
+  `didTimeout` tinyint(1) unsigned NOT NULL,
+  PRIMARY KEY (`gameID`,`userID`)
 ) ENGINE=InnoDB DEFAULT CHARSET=latin1;
 /*!40101 SET character_set_client = @saved_cs_client */;
 


### PR DESCRIPTION
The altar table statement is:
    ALTER TABLE GameUser ADD PRIMARY KEY (gameID, userID);

On a local test setup with 1000 users and 70000 games this reduces the game api query on a user page from 760ms to 5ms, and on the recent_games page from 2 seconds to 100ms. Currently the recent_games request on the live server typically takes between 2.5-3.5 seconds.