### PR TITLE
Add worker manager contributing documentation

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -23,7 +23,9 @@ Edit [this whitelist](https://github.com/HaliteChallenge/Halite/edit/master/webs
 - `website/` - The website that hosts the competition. Includes the API that manages the game servers.
 - `worker/` - The source for the worker servers that compile bots and run games safely
 
-## Installing the website on Ubuntu
+## Installation 
+
+### Installing the website on Ubuntu
 
 Clone the repo:
 
@@ -33,7 +35,7 @@ Run the website install script with root user permissions. This will install php
 
     cd website; sudo ./install.sh
 
-Run the database install script with root user permissions. This will install mysql and insert our schema into a database titled Halite.
+Run the database install script with root user permissions. This will install mysql, insert our schema into a database titled Halite, and import some dummy users.
 
     cd sql; sudo ./install.sh
 
@@ -44,3 +46,26 @@ Create a `halite.ini` file using your favorite text editor in the root project d
     username = YOUR_LOCAL_MYSQL_USERNAME
     password = YOUR_LOCAL_MYSQL_PASSWORD
     name = Halite
+
+### Setting up the manager and worker on Ubuntu 
+
+We assume that you have already followed "Installing the website on Ubuntu."
+
+Run the worker install script. It will install some required libraries, switch your default compiler to g++4.9, build our docker sandbox, and enable swap memory:
+    
+    cd worker; sudo ./install.sh
+
+Add these lines to your `halite.ini` file:
+
+    [hce]
+    managerURl = http://localhost/website/api/manager/
+    apiKey = 1 
+    secretFolder = blah_blah_blah
+
+Reboot your system (because of the enabling of swap memory):
+    
+    sudo reboot
+
+Start a worker:
+
+    cd worker; sudo python3 worker.py

--- a/website/api/manager/ManagerAPI.php
+++ b/website/api/manager/ManagerAPI.php
@@ -185,7 +185,7 @@ class ManagerAPI extends API{
                 }
 
 
-                $s3Client->putObject($args);
+                //$s3Client->putObject($args);
             }
 
             // Check that we arent stoing too many games in db

--- a/website/sql/dummyData.sql
+++ b/website/sql/dummyData.sql
@@ -1,3 +1,4 @@
 DELETE FROM User;
 
-INSERT INTO User (username, email, compileStatus, isRunning, language, organization) VALUES ('John Doe', 'jane_doe@gmail.com', 0, 1, 'Java', 'Other'), ('Jane Doe', 'jane_doe@gmail.com', 0, 1, 'Python', 'Other');
+INSERT INTO User (userID, username, email, compileStatus, isRunning, language, organization) VALUES (2609, 'erdman', 'abc@gmail.com', 0, 1, 'Python', 'Other'), (1017, 'djma', 'abc@gmail.com', 0, 1, 'Java', 'Other'), (3063, 'daniel-shields', 'abc@gmail.com', 0, 1, 'Python', 'Other');
+INSERT INTO Worker (apiKey, ipAddress) VALUES (1, "127.0.0.1");

--- a/website/sql/importDummyData.sh
+++ b/website/sql/importDummyData.sh
@@ -1,11 +1,5 @@
 #!/bin/bash
 
-echo "Are you sure that you want to run this script??? It will erase everything in your db. Answer [y/n]:"
-
-read ANSWER
-
-if [ "$ANSWER" == "y" ]; then
-    echo "drop database Halite; create database Halite;" | mysql -u root
-    mysql -u root Halite < schema.sql 
-    mysql -u root Halite < dummyData.sql
-fi
+echo "drop database Halite; create database Halite;" | mysql -u root -p
+mysql -u root Halite < schema.sql -p
+mysql -u root Halite < dummyData.sql -p

--- a/website/sql/install.sh
+++ b/website/sql/install.sh
@@ -1,5 +1,4 @@
 sudo apt-get install -y mysql-server
 
 echo "Starting MySql setup"
-echo "create database Halite;" | mysql -u root -p
-mysql -u root -p Halite < schema.sql
+./importDummyData.sh

--- a/worker/worker.py
+++ b/worker/worker.py
@@ -31,8 +31,6 @@ parser = configparser.ConfigParser()
 parser.read("../halite.ini")
 
 RUN_GAME_FILE_NAME = "runGame.sh"
-HALITE_EMAIL = parser["email"]["email"]
-HALITE_EMAIL_PASSWORD = parser["email"]["password"]
 SECRET_FOLDER = parser["hce"]["secretFolder"]
 
 def makePath(path):


### PR DESCRIPTION
Gonna require some code changes, since running the worker manager system locally requires our AWS credentials right now (for pulling bot source and for pushing replay files and error logs).