### PR TITLE
Possible runaway crash bot fix.

### DIFF
--- a/website/api/manager/ManagerAPI.php
+++ b/website/api/manager/ManagerAPI.php
@@ -99,7 +99,7 @@ class ManagerAPI extends API{
 
             $muRankLimit = intval(5.0 / pow((float)mt_rand(1, mt_getrandmax())/(float)mt_getrandmax(), 0.65));
             $players = $this->selectMultiple("SELECT * FROM (SELECT * FROM User WHERE isRunning=1 and userID <> {$seedPlayer['userID']} ORDER BY ABS(mu-{$seedPlayer['mu']}) LIMIT $muRankLimit) muRankTable ORDER BY rand() LIMIT ".($numPlayers-1));
-            array_push($players, $seedPlayer);
+            array_unshift($players, $seedPlayer);
 
             // Pick map size
             $sizes = array(20, 25, 25, 30, 30, 30, 35, 35, 35, 35, 40, 40, 40, 45, 45, 50);


### PR DESCRIPTION
Note that this won't immediately stop the runaway from getting games, but the runaway should immediately start winning games. This should bring things back into balance fairly soon.

The following is my monologue from discord where I discover and go through the problem:
> Somehow Sametine manages to come in last for every single game, even though pretty much all his opponents now are immediate crashers. https://halite.io/user.php?userID=4246
This has driven his mu down to -25.56 which in itself isn't necessarily a problem. But since the next closest mu is around -1.9 there are no opponents anywhere near his mu which means his sigma has greatly increased since the system has no idea how far down his mu should be.
So his sigma is now at 2.66
That is a problem
fresh submissions start at 2.33
which means that Sametine now gets a large portion of all the games played (I guess the good thing is that they happen very fast :wink: )
He appears to be playing at a rate of >12 games per minute.
recently total game rate has been right around 12 games per minute.
which means this is helping the overall game rate since it seems he's in less than half the games being played currently
seed locking would help a little bit, changing from high sigma to number of games played would solve it
@truell20 you'll probably want to look into the above when you get up
the whole situation I mean not specifically the previous line
ahh, I have a theory (or hypothesis at least) on how the situation arose.
I'm guessing when multiple players timeout (even possibly any loss) on the same turn they are ordered by player number, i.e. the higher the playertag the lower they rank for the game.
when players are assigned to a game the seed player is always pushed onto the end of the list and gets the highest playertag
so amongst a group of crash bots eventually by chance one gets chosen as seed a few times in a row
eventually this happens to push that bots sigma up enough that it starts getting picked as a seed even more
and then the whole thing spirals out of control and goes boom
simply placing the seed at the beginning of the player list would probably mitigate this particular issue
php array_unshift would seem to be the function wanted
