### PR TITLE
Use correct draw_probability of zero for trueskill.

### DIFF
--- a/website/api/manager/updateTrueskill.py
+++ b/website/api/manager/updateTrueskill.py
@@ -5,6 +5,7 @@ sys.argv.pop(0)
 
 teams = [[trueskill.Rating(mu=float(sys.argv[a]), sigma=float(sys.argv[a+1]))] for a in range(0, len(sys.argv), 2)]
 
-newRatings = trueskill.rate(teams)
+ts_env = trueskill.TrueSkill(draw_probability=0.)
+newRatings = ts_env.rate(teams)
 for rating in newRatings:
     print(str(rating[0].mu) + " " + str(rating[0].sigma))


### PR DESCRIPTION
This is mostly just a pedantic make it technically correct fix. In my testing it makes an almost negligible difference but does slightly improve the rankings.