### PR TITLE
Performance improvement for Java Starter Package: Got rid of object churn

### DIFF
--- a/airesources/Java/Direction.java
+++ b/airesources/Java/Direction.java
@@ -6,26 +6,8 @@ public enum Direction {
     public static final Direction[] DIRECTIONS = new Direction[]{STILL, NORTH, EAST, SOUTH, WEST};
     public static final Direction[] CARDINALS = new Direction[]{NORTH, EAST, SOUTH, WEST};
 
-    private static Direction fromInteger(int value) {
-        if(value == 0) {
-            return STILL;
-        }
-        if(value == 1) {
-            return NORTH;
-        }
-        if(value == 2) {
-            return EAST;
-        }
-        if(value == 3) {
-            return SOUTH;
-        }
-        if(value == 4) {
-            return WEST;
-        }
-        return null;
-    }
-
     public static Direction randomDirection() {
-        return fromInteger(new Random().nextInt(5));
+        Direction[] values = values();
+        return values[new Random().nextInt(values.length)];
     }
 }

--- a/airesources/Java/GameMap.java
+++ b/airesources/Java/GameMap.java
@@ -1,24 +1,23 @@
 import java.util.ArrayList;
 public class GameMap{
-    public ArrayList< ArrayList<Site> > contents;
-    public int width, height;
 
-    public GameMap() {
-        width = 0;
-        height = 0;
-        contents = new ArrayList< ArrayList<Site> >(0);
-    }
+    private final Site[][] contents;
+    private final Location[][] locations;
+    public final int width, height;
 
-    public GameMap(int width_, int height_) {
-        width = width_;
-        height = height_;
-        contents = new ArrayList< ArrayList<Site> >(0);
-        for(int y = 0; y < height; y++) {
-            ArrayList<Site> row = new ArrayList<Site>();
+    public GameMap(int width, int height, int[][] productions) {
+
+        this.width = width;
+        this.height = height;
+        this.contents = new Site[width][height];
+        this.locations = new Location[width][height];
+
+        for (int y = 0; y < height; y++) {
             for(int x = 0; x < width; x++) {
-                row.add(new Site());
+                final Site site = new Site(productions[x][y]);
+                contents[x][y] = site;
+                locations[x][y] = new Location(x, y, site);
             }
-            contents.add(row);
         }
     }
 
@@ -52,35 +51,42 @@ public class GameMap{
         return Math.atan2(dy, dx);
     }
 
-    public Location getLocation(Location loc, Direction dir) {
-        Location l = new Location(loc);
-        if(dir != Direction.STILL) {
-            if(dir == Direction.NORTH) {
-                if(l.y == 0) l.y = height - 1;
-                else l.y--;
-            }
-            else if(dir == Direction.EAST) {
-                if(l.x == width - 1) l.x = 0;
-                else l.x++;
-            }
-            else if(dir == Direction.SOUTH) {
-                if(l.y == height - 1) l.y = 0;
-                else l.y++;
-            }
-            else if(dir == Direction.WEST) {
-                if(l.x == 0) l.x = width - 1;
-                else l.x--;
-            }
+    public Location getLocation(Location location, Direction direction) {
+        switch (direction) {
+            case STILL:
+                return location;
+            case NORTH:
+                return locations[location.getX()][(location.getY() == 0 ? height : location.getY()) -1];
+            case EAST:
+                return locations[location.getX() == width - 1 ? 0 : location.getX() + 1][location.getY()];
+            case SOUTH:
+                return locations[location.getX()][location.getY() == height - 1 ? 0 : location.getY() + 1];
+            case WEST:
+                return locations[(location.getX() == 0 ? width : location.getX()) - 1][location.getY()];
+            default:
+                throw new IllegalArgumentException(String.format("Unknown direction %s encountered", direction));
         }
-        return l;
     }
 
     public Site getSite(Location loc, Direction dir) {
-        Location l = getLocation(loc, dir);
-        return contents.get(l.y).get(l.x);
+        return getLocation(loc, dir).getSite();
     }
 
     public Site getSite(Location loc) {
-        return contents.get(loc.y).get(loc.x);
+        return loc.getSite();
+    }
+
+    public Location getLocation(int x, int y) {
+        return locations[x][y];
+    }
+
+    void reset() {
+        for (int y = 0; y < height; y++) {
+            for (int x = 0; x < width; x++) {
+                final Site site = contents[x][y];
+                site.owner = 0;
+                site.strength = 0;
+            }
+        }
     }
 }

--- a/airesources/Java/Location.java
+++ b/airesources/Java/Location.java
@@ -1,12 +1,24 @@
 public class Location {
-    public int x, y;
 
-    public Location(int x_, int y_) {
-        x = x_;
-        y = y_;
+    // Public for backward compability
+    public final int x, y;
+    private final Site site;
+
+    public Location(int x, int y, Site site) {
+        this.x = x;
+        this.y = y;
+        this.site = site;
     }
-    public Location(Location l) {
-        x = l.x;
-        y = l.y;
+
+    public int getX() {
+        return x;
+    }
+
+    public int getY() {
+        return y;
+    }
+
+    public Site getSite() {
+        return site;
     }
 }

--- a/airesources/Java/MyBot.java
+++ b/airesources/Java/MyBot.java
@@ -1,24 +1,26 @@
 import java.util.ArrayList;
+import java.util.List;
 
 public class MyBot {
     public static void main(String[] args) throws java.io.IOException {
-        InitPackage iPackage = Networking.getInit();
-        int myID = iPackage.myID;
-        GameMap gameMap = iPackage.map;
+
+        final InitPackage iPackage = Networking.getInit();
+        final int myID = iPackage.myID;
+        final GameMap gameMap = iPackage.map;
 
         Networking.sendInit("MyJavaBot");
 
         while(true) {
-            ArrayList<Move> moves = new ArrayList<Move>();
+            List<Move> moves = new ArrayList<Move>();
 
-            gameMap = Networking.getFrame();
+            Networking.updateFrame(gameMap);
 
-            for(int y = 0; y < gameMap.height; y++) {
-                for(int x = 0; x < gameMap.width; x++) {
-                    Site site = gameMap.getSite(new Location(x, y));
+            for (int y = 0; y < gameMap.height; y++) {
+                for (int x = 0; x < gameMap.width; x++) {
+                    final Location location = gameMap.getLocation(x, y);
+                    final Site site = location.getSite();
                     if(site.owner == myID) {
-                        Direction dir = Direction.randomDirection();
-                        moves.add(new Move(new Location(x, y), dir));
+                        moves.add(new Move(location, Direction.randomDirection()));
                     }
                 }
             }

--- a/airesources/Java/Networking.java
+++ b/airesources/Java/Networking.java
@@ -4,57 +4,57 @@ import java.util.ArrayList;
 import java.util.Scanner;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
+import java.util.List;
 
 public class Networking {
-    public static final int SIZE_OF_INTEGER_PREFIX = 4;
-    public static final int CHAR_SIZE = 1;
-    private static int _width, _height;
-    private static ArrayList< ArrayList<Integer> > _productions;
 
-    static void deserializeGameMapSize(String inputString) {
-        String[] inputStringComponents = inputString.split(" ");
-
-        _width = Integer.parseInt(inputStringComponents[0]);
-        _height = Integer.parseInt(inputStringComponents[1]);
-    }
-
-
-    static void deserializeProductions(String inputString) {
+    static int[][] deserializeProductions(String inputString, int width, int height) {
         String[] inputStringComponents = inputString.split(" ");
 
         int index = 0;
-        _productions = new ArrayList< ArrayList<Integer> >();
-        for(int a = 0; a < _height; a++) {
-            ArrayList<Integer> row = new ArrayList<Integer>();
-            for(int b = 0; b < _width; b++) {
-                row.add(Integer.parseInt(inputStringComponents[index]));
+        int[][] productions = new int[width][height];
+
+        for (int y = 0; y < height; y++) {
+            for (int x = 0; x < width; x++) {
+                productions[x][y] = Integer.parseInt(inputStringComponents[index]);
                 index++;
             }
-            _productions.add(row);
         }
+
+        return productions;
     }
 
-    static String serializeMoveList(ArrayList<Move> moves) {
+    static String serializeMoveList(List<Move> moves) {
         StringBuilder builder = new StringBuilder();
-        for(Move move : moves) builder.append(move.loc.x + " " + move.loc.y + " " + move.dir.ordinal() + " ");
+        for (Move move : moves) {
+            builder.append(move.loc.x)
+                .append(" ")
+                .append(move.loc.y)
+                .append(" ")
+                .append(move.dir.ordinal())
+                .append(" ");
+        }
         return builder.toString();
     }
 
-    static GameMap deserializeGameMap(String inputString) {
+    static GameMap deserializeGameMap(String inputString, GameMap map) {
         String[] inputStringComponents = inputString.split(" ");
-
-        GameMap map = new GameMap(_width, _height);
 
         // Run-length encode of owners
         int y = 0, x = 0;
         int counter = 0, owner = 0;
         int currentIndex = 0;
-        while(y != map.height) {
+
+
+        while (y != map.height) {
+
             counter = Integer.parseInt(inputStringComponents[currentIndex]);
             owner = Integer.parseInt(inputStringComponents[currentIndex + 1]);
+
             currentIndex += 2;
-            for(int a = 0; a < counter; ++a) {
-                map.contents.get(y).get(x).owner = owner;
+            for (int a = 0; a < counter; a++) {
+
+                map.getLocation(x,y).getSite().owner = owner;
                 ++x;
                 if(x == map.width) {
                     x = 0;
@@ -63,12 +63,11 @@ public class Networking {
             }
         }
 
-        for (int a = 0; a < map.contents.size(); ++a) {
-            for (int b = 0; b < map.contents.get(a).size(); ++b) {
+        for (int b = 0; b < map.height; b++) {
+            for (int a = 0; a < map.width; a++) {
                 int strengthInt = Integer.parseInt(inputStringComponents[currentIndex]);
                 currentIndex++;
-                map.contents.get(a).get(b).strength = strengthInt;
-                map.contents.get(a).get(b).production = _productions.get(a).get(b);
+                map.getLocation(a,b).getSite().strength = strengthInt;
             }
         }
 
@@ -100,11 +99,22 @@ public class Networking {
     }
 
     static InitPackage getInit() {
+
         InitPackage initPackage = new InitPackage();
         initPackage.myID = (int)Integer.parseInt(getString());
-        deserializeGameMapSize(getString());
-        deserializeProductions(getString());
-        initPackage.map = deserializeGameMap(getString());
+
+        // Deserialize width and height:
+        final String[] inputStringComponents = getString().split(" ");
+
+        int width = Integer.parseInt(inputStringComponents[0]);
+        int height = Integer.parseInt(inputStringComponents[1]);
+
+        int[][] productions = deserializeProductions(getString(), width, height);
+
+        GameMap map = new GameMap(width, height, productions);
+        deserializeGameMap(getString(), map);
+
+        initPackage.map = map;
 
         return initPackage;
     }
@@ -113,11 +123,12 @@ public class Networking {
         sendString(name);
     }
 
-    static GameMap getFrame() {
-        return deserializeGameMap(getString());
+    static void updateFrame(GameMap map) {
+        map.reset();
+        deserializeGameMap(getString(), map);
     }
 
-    static void sendFrame(ArrayList<Move> moves) {
+    static void sendFrame(List<Move> moves) {
         sendString(serializeMoveList(moves));
     }
 

--- a/airesources/Java/RandomBot.java
+++ b/airesources/Java/RandomBot.java
@@ -1,28 +1,30 @@
 import java.util.ArrayList;
+import java.util.List;
 
 public class RandomBot {
     public static void main(String[] args) throws java.io.IOException {
-        InitPackage iPackage = Networking.getInit();
-        int myID = iPackage.myID;
-        GameMap gameMap = iPackage.map;
+
+        final InitPackage iPackage = Networking.getInit();
+        final int myID = iPackage.myID;
+        final GameMap gameMap = iPackage.map;
 
         Networking.sendInit("RandomJavaBot");
 
         while(true) {
-            ArrayList<Move> moves = new ArrayList<Move>();
+            List<Move> moves = new ArrayList<Move>();
 
-            gameMap = Networking.getFrame();
+            Networking.updateFrame(gameMap);
 
-            for(int y = 0; y < gameMap.height; y++) {
-                for(int x = 0; x < gameMap.width; x++) {
-                    Site site = gameMap.getSite(new Location(x, y));
+            for (int y = 0; y < gameMap.height; y++) {
+                for (int x = 0; x < gameMap.width; x++) {
+                    final Location location = gameMap.getLocation(x, y);
+                    final Site site = location.getSite();
                     if(site.owner == myID) {
-                        Direction dir = Direction.randomDirection();
-                        moves.add(new Move(new Location(x, y), dir));
+                        moves.add(new Move(location, Direction.randomDirection()));
                     }
                 }
             }
-        Networking.sendFrame(moves);
+            Networking.sendFrame(moves);
         }
     }
 }

--- a/airesources/Java/Site.java
+++ b/airesources/Java/Site.java
@@ -1,3 +1,9 @@
 public class Site {
-    public int owner, strength, production;
+
+    private final int production;
+    public int owner, strength;
+
+    public Site(int production) {
+        this.production = production;
+    }
 }


### PR DESCRIPTION
The current implementation of the Java starter package has the disadvantage that it produces a lot of object churn mainly because the game map is re-created upon each turn. This pull request contains a modified version of the starter package which prevents the object churn by creating the game map, locations, and sites once and updating them later on.