### PR TITLE
Clear graphics before toggling extra graphs.

### DIFF
--- a/website/script/visualizer.js
+++ b/website/script/visualizer.js
@@ -181,6 +181,8 @@ function showGame(game, $container, maxWidth, maxHeight, showmovement, isminimal
         }
         else if(e.keyCode == 69) { //e
             showExtended = !showExtended;
+            mapGraphics.clear();
+            graphGraphics.clear();
             window.onresize();
         }
         else if(e.keyCode == 90) { //z


### PR DESCRIPTION
When toggling the graphs it changes the aspect ratio and can leave garbage on the screen in some cases on some browsers. This clears the current map and graphs before making the change.