### PR TITLE
Scala starter package bug: Fix size parsing for unequal width/height

### DIFF
--- a/airesources/Scala/Bot.scala
+++ b/airesources/Scala/Bot.scala
@@ -1,5 +1,5 @@
 trait Bot {
-  def getMoves(grid: Grid): IndexedSeq[Move]
+  def getMoves(grid: Grid): Iterable[Move]
 }
 
 trait BotFactory {

--- a/airesources/Scala/Env.scala
+++ b/airesources/Scala/Env.scala
@@ -1,17 +1,15 @@
-import scala.Console._
-
 object Env {
   def readId(): Int = {
-    in.readLine().toInt
+    read().toInt
   }
 
   def readInit(): Grid = {
-    val dims = in.readLine().split(" ")
+    val dims = read().split(" ")
     val width = dims(0).toInt
     val height = dims(1).toInt
 
-    val locations = Array.ofDim[Location](width, height)
-    val productions = in.readLine().split(" ")
+    val locations = Array.ofDim[Location](height, width)
+    val productions = read().split(" ")
 
     for (y <- 0 until height) {
       for (x <- 0 until width) {
@@ -24,13 +22,13 @@ object Env {
   }
 
   def readFrame(width: Int, height: Int): Array[Array[Occupant]] = {
-    val ownersStrengths = in.readLine().split(" ")
+    val ownersStrengths = read().split(" ")
     val strengthsIndex = ownersStrengths.length - width * height
 
     var y, x, count = 0
     var owner, cur, i = 0
 
-    val occupants = Array.ofDim[Occupant](width, height)
+    val occupants = Array.ofDim[Occupant](height, width)
     while (y < height) {
       if (cur < count) {
         occupants(y)(x) = Occupant(owner, ownersStrengths(strengthsIndex + y * width + x).toInt)
@@ -52,12 +50,12 @@ object Env {
     occupants
   }
 
-  def writeFrame(moves: IndexedSeq[Move]): Unit = {
+  def writeFrame(moves: Iterable[Move]): Unit = {
     val builder = new StringBuilder()
     moves foreach { m =>
-      builder.append(m.x)
+      builder.append(m.location.x)
       builder.append(" ")
-      builder.append(m.y)
+      builder.append(m.location.y)
       builder.append(" ")
       builder.append(m.direction.getValue)
       builder.append(" ")
@@ -70,7 +68,17 @@ object Env {
   }
 
   private def writeString(s: String): Unit = {
-    print(s + '\n')
-    flush()
+    System.out.print(s + '\n')
+    System.out.flush()
+  }
+
+  private def read(): String = {
+    val buffer = new StringBuilder()
+    var next = System.in.read()
+    while (next != '\n' && next != 0) {
+      buffer.append(next.asInstanceOf[Char])
+      next = System.in.read()
+    }
+    buffer.toString
   }
 }

--- a/airesources/Scala/Move.scala
+++ b/airesources/Scala/Move.scala
@@ -1,1 +1,1 @@
-case class Move(x: Int, y: Int, direction: Direction)
+case class Move(location: Location, direction: Direction)

--- a/airesources/Scala/MyBot.scala
+++ b/airesources/Scala/MyBot.scala
@@ -1,5 +1,3 @@
-import scala.util.Random
-
 object MyBot extends BotFactory {
   def main(args: Array[String]): Unit = {
     Runner.run("scalaMyBot", this)
@@ -8,13 +6,10 @@ object MyBot extends BotFactory {
   override def make(id: Int): Bot = new MyBot(id)
 }
 
-class MyBot(id: Int) extends Bot {
-  val random = new Random()
-
-  override def getMoves(grid: Grid): IndexedSeq[Move] = {
+class MyBot(myId: Int) extends Bot {
+  override def getMoves(grid: Grid): Iterable[Move] = {
     for {
-      space <- grid.getSites
-      if space.occupant.id == id
-    } yield Move(space.location.x, space.location.y, Direction.getRandomDir)
+      site <- grid.getMine(myId)
+    } yield Move(site.location, Direction.getRandomDir)
   }
 }

--- a/airesources/Scala/RandomBot.scala
+++ b/airesources/Scala/RandomBot.scala
@@ -1,5 +1,3 @@
-import scala.util.Random
-
 object RandomBot extends BotFactory {
   def main(args: Array[String]): Unit = {
     Runner.run("scalaRandom", this)
@@ -8,13 +6,10 @@ object RandomBot extends BotFactory {
   override def make(id: Int): Bot = new RandomBot(id)
 }
 
-class RandomBot(id: Int) extends Bot {
-  val random = new Random()
-
-  override def getMoves(grid: Grid): IndexedSeq[Move] = {
+class RandomBot(myId: Int) extends Bot {
+  override def getMoves(grid: Grid): Iterable[Move] = {
     for {
-      space <- grid.getSites
-      if space.occupant.id == id
-    } yield Move(space.location.x, space.location.y, Direction.getRandomDir)
+      site <- grid.getMine(myId)
+    } yield Move(site.location, Direction.getRandomDir)
   }
 }


### PR DESCRIPTION
This is an important fix for the Scala starter package. It currently crashes if width/height are not equal.

Note that the Scala starter package depends on the below PR to compile correctly on the server without any .java files: https://github.com/HaliteChallenge/Halite/pull/335

Cleaned up the interface and added utilities I've found useful.