### PR TITLE
Eliminate error column in user page gamelist.

### DIFF
--- a/website/script/user.js
+++ b/website/script/user.js
@@ -175,9 +175,7 @@ $(function() {
                 this.$alternateMessage.css("display", "block");
                 this.$panel.css("display", "none");
             } else {
-                var errorHeader = "<th>Error</th>";
-                if(this.isMe) { errorHeader = "<th>Error Log</th>"; }
-                this.$tableHeader.html("<th>Time</th><th>Opponents</th><th>Result</th>"+ errorHeader +"<th>Dimensions</th><th>View</th>");
+                this.$tableHeader.html("<th>Time</th><th>Opponents</th><th>Result</th><th>Dimensions</th><th>View</th>");
                 this.$tableBody.empty();
                 for(var a = 0; a < this.games.length; a++) {
                     this.$tableBody.append(this.getTableRow(this.games[a]));
@@ -206,15 +204,15 @@ $(function() {
                     break;
                 }
             }
-            var errorMsg = "&mdash;";
+            var errorMsg = "";
             if(me.errorLogName != undefined && me.errorLogName != null) {
                 if(this.isMe) {
-                    errorMsg = "<a target='_blank' href='"+url+"errorLog?errorLogName="+me.errorLogName+"'><span class='glyphicon glyphicon-save-file'></span></a>";
+                    errorMsg = "<a target='_blank' href='"+url+"errorLog?errorLogName="+me.errorLogName+"'><span class='glyphicon glyphicon-save-file' title='Click to view error log'></span></a>";
                 } else {
-                    errorMsg = "<span class='glyphicon glyphicon-exclamation-sign'></span>";
+                    errorMsg = "<span class='glyphicon glyphicon-exclamation-sign' title='Ended game with an error'></span>";
                 }
             }
-            var $row = $("<tr><td>"+gameDate.toLocaleTimeString()+"</td><td>"+playersList+"</td><td>"+result+"</td><td>"+errorMsg+"</td><td>"+game.mapWidth+"x"+game.mapHeight+"</td><td><a href='game.php?replay="+game.replayName+"'><span class='glyphicon glyphicon-film'></span></a></td></tr>");
+            var $row = $("<tr><td>"+gameDate.toLocaleTimeString()+"</td><td>"+playersList+"</td><td>"+result+" "+errorMsg+"</td><td>"+game.mapWidth+"x"+game.mapHeight+"</td><td><a href='game.php?replay="+game.replayName+"'><span class='glyphicon glyphicon-film'></span></a></td></tr>");
             return $row;
         },
         loadMore: function() {

--- a/website/script/user.js
+++ b/website/script/user.js
@@ -198,10 +198,14 @@ $(function() {
             var gameDate = new Date(Date.UTC(dateComponents[0], dateComponents[1]-1, dateComponents[2], dateComponents[3], dateComponents[4], dateComponents[5]));
 
             var me = null;
+            var numErrors = 0;
             for(var a = 0; a < game.users.length; a++) {
-                if(game.users[a].userID == this.userID) {
-                    me = game.users[a];
-                    break;
+                var u = game.users[a];
+                if(u.userID == this.userID) {
+                    me = u;
+                }
+                if(u.errorLogName != undefined && u.errorLogName != null){
+                    numErrors += 1;
                 }
             }
             var errorMsg = "";
@@ -211,6 +215,10 @@ $(function() {
                 } else {
                     errorMsg = "<span class='glyphicon glyphicon-exclamation-sign' title='Ended game with an error'></span>";
                 }
+            } else if(numErrors == 1) {
+                errorMsg = "<span class='glyphicon glyphicon-asterisk' title='One opponent errored out.'></span>";
+            } else if(numErrors > 1) {
+                errorMsg = "<span class='glyphicon glyphicon-asterisk' title='"+numErrors+" opponents errored out.'></span>";
             }
             var $row = $("<tr><td>"+gameDate.toLocaleTimeString()+"</td><td>"+playersList+"</td><td>"+result+" "+errorMsg+"</td><td>"+game.mapWidth+"x"+game.mapHeight+"</td><td><a href='game.php?replay="+game.replayName+"'><span class='glyphicon glyphicon-film'></span></a></td></tr>");
             return $row;

--- a/website/script/user.js
+++ b/website/script/user.js
@@ -210,10 +210,16 @@ $(function() {
             }
             var errorMsg = "";
             if(me.errorLogName != undefined && me.errorLogName != null) {
+                var tooltip = "Ended game with an error";
+                if(numErrors > 1) {
+                    tooltip = "This bot and "+(numErrors - 1)+" other";
+                    if(numErrors > 2) { tooltip += "s"; }
+                    tooltip += " errored out";
+                }
                 if(this.isMe) {
-                    errorMsg = "<a target='_blank' href='"+url+"errorLog?errorLogName="+me.errorLogName+"'><span class='glyphicon glyphicon-save-file' title='Click to view error log'></span></a>";
+                    errorMsg = "<a target='_blank' href='"+url+"errorLog?errorLogName="+me.errorLogName+"'><span class='glyphicon glyphicon-save-file' title='"+tooltip+"'></span></a>";
                 } else {
-                    errorMsg = "<span class='glyphicon glyphicon-exclamation-sign' title='Ended game with an error'></span>";
+                    errorMsg = "<span class='glyphicon glyphicon-exclamation-sign' title='"+tooltip+"'></span>";
                 }
             } else if(numErrors == 1) {
                 errorMsg = "<span class='glyphicon glyphicon-asterisk' title='One opponent errored out.'></span>";


### PR DESCRIPTION
Follow on to PR #392 getting rid of the error column altogether and displaying it as part of the result. (See screenshot in #392)

Can close if you like the explicit column better.