### PR TITLE
Return GameUser.versionNumber in api/web/game results.

### DIFF
--- a/website/api/web/WebsiteAPI.php
+++ b/website/api/web/WebsiteAPI.php
@@ -326,7 +326,7 @@ class WebsiteAPI extends API{
             $gameID = $gameArray['gameID'];
 
             // Get information about users
-            $gameArray['users'] = $this->selectMultiple("SELECT gu.userID, gu.errorLogName, gu.rank, u.username, u.oauthID, u.mu, u.sigma, u.rank AS userRank FROM GameUser gu INNER JOIN User u ON u.userID=gu.userID WHERE gu.gameID = $gameID");
+            $gameArray['users'] = $this->selectMultiple("SELECT gu.userID, gu.versionNumber, gu.errorLogName, gu.rank, u.username, u.oauthID, u.mu, u.sigma, u.rank AS userRank FROM GameUser gu INNER JOIN User u ON u.userID=gu.userID WHERE gu.gameID = $gameID");
         }
         return $gameArrays;
     }


### PR DESCRIPTION
This makes it much easier to tell which version of an opponent was actually playing in a game.

The motivating reason is for people getting the game information to run their own rating methods.