### PR TITLE
Script to reset all user ranks and scores.

### DIFF
--- a/admin/rankReset.py
+++ b/admin/rankReset.py
@@ -1,0 +1,26 @@
+#!/usr/bin/env python3
+
+import configparser
+import pymysql
+
+parser = configparser.ConfigParser()
+parser.read("../halite.ini")
+
+DB_CONFIG = parser["database"]
+
+def main():
+    confirm = input("This will clear all current ranks, are you sure? [y/N] ")
+    if confirm != "y":
+        return
+    db = pymysql.connect(host=DB_CONFIG["hostname"], user=DB_CONFIG['username'], passwd=DB_CONFIG['password'], db=DB_CONFIG['name'], cursorclass=pymysql.cursors.DictCursor)
+    cursor = db.cursor()
+    cursor.execute("SELECT COUNT(*) FROM User WHERE isRunning=1")
+    num_active = cursor.fetchone()['COUNT(*)']
+    cursor.execute("INSERT INTO UserHistory (userID, versionNumber, lastRank, lastNumPlayers, lastNumGames) SELECT userID, numSubmissions, rank, %d, numGames FROM User WHERE isRunning=1" % (num_active,))
+    cursor.execute("UPDATE User SET numSubmissions=numSubmissions+1, numGames=0, mu=25.0, sigma=8.333 WHERE isRunning=1")
+    db.commit()
+    db.close()
+    print("All ranks successfully reset.")
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
This is a script to reset the ranks for the start of finals. It saves all of the current ranks and number of games by acting as if every user had resubmitted a new bot.

I've tested locally but would love to hear that someone else tested it before it is actually used live.